### PR TITLE
fix the local-name function calls

### DIFF
--- a/lib/dynamics_crm/client.rb
+++ b/lib/dynamics_crm/client.rb
@@ -78,7 +78,7 @@ module DynamicsCRM
 
       document = REXML::Document.new(soap_response)
       # Check for Fault
-      fault_xml = document.get_elements("//[local-name() = 'Fault']")
+      fault_xml = document.get_elements("//*[local-name() = 'Fault']")
       raise XML::Fault.new(fault_xml) if fault_xml.any?
 
       if on_premise?
@@ -102,7 +102,7 @@ module DynamicsCRM
           @security_token0 = cipher_values[0].text
           @security_token1 = cipher_values[1].text
           # Use local-name() to ignore namespace.
-          @key_identifier = document.get_elements("//[local-name() = 'KeyIdentifier']").first.text
+          @key_identifier = document.get_elements("//*[local-name() = 'KeyIdentifier']").first.text
         else
           raise RuntimeError.new(soap_response)
         end

--- a/lib/dynamics_crm/metadata/xml_document.rb
+++ b/lib/dynamics_crm/metadata/xml_document.rb
@@ -14,7 +14,7 @@ module DynamicsCRM
         return value if @document.nil?
 
         camel_name = method.to_s
-        element = @document.get_elements("./[local-name() = '#{camel_name}']").first
+        element = @document.get_elements("./*[local-name() = '#{camel_name}']").first
 
         if element && element.children.size == 1 && element.children.first.is_a?(REXML::Text)
           value = element.text

--- a/lib/dynamics_crm/response/result.rb
+++ b/lib/dynamics_crm/response/result.rb
@@ -7,7 +7,7 @@ module DynamicsCRM
       def initialize(xml)
         @document = REXML::Document.new(xml)
 
-        fault_xml = @document.get_elements("//[local-name() = 'Fault']")
+        fault_xml = @document.get_elements("//*[local-name() = 'Fault']")
         raise XML::Fault.new(fault_xml) if fault_xml.any?
 
         @result_response = @document.get_elements("//#{response_element}").first

--- a/lib/dynamics_crm/xml/fault.rb
+++ b/lib/dynamics_crm/xml/fault.rb
@@ -12,12 +12,12 @@ module DynamicsCRM
           fault_xml = fault_xml.first
         end
         # REXL::Element
-        @code = fault_xml.get_text("//[local-name() = 'Code']/[local-name() = 'Value']")
-        @subcode = fault_xml.get_text("//[local-name() = 'Code']/[local-name() = 'Subcode']/[local-name() = 'Value']")
-        @reason = fault_xml.get_text("//[local-name() = 'Reason']/[local-name() = 'Text']")
+        @code = fault_xml.get_text("//*[local-name() = 'Code']/*[local-name() = 'Value']")
+        @subcode = fault_xml.get_text("//*[local-name() = 'Code']/*[local-name() = 'Subcode']/*[local-name() = 'Value']")
+        @reason = fault_xml.get_text("//*[local-name() = 'Reason']/*[local-name() = 'Text']")
 
         @detail = {}
-        detail_fragment = fault_xml.get_elements("//[local-name() = 'Detail']").first
+        detail_fragment = fault_xml.get_elements("//*[local-name() = 'Detail']").first
         if detail_fragment
           fault_type = detail_fragment.elements.first
           @detail[:type] = fault_type.name

--- a/spec/lib/xml/fault_spec.rb
+++ b/spec/lib/xml/fault_spec.rb
@@ -7,7 +7,7 @@ describe DynamicsCRM::XML::Fault do
     context "receiver fault" do
       subject {
         document = REXML::Document.new(fixture('receiver_fault'))
-        fault = document.get_elements("//[local-name() = 'Fault']")
+        fault = document.get_elements("//*[local-name() = 'Fault']")
         DynamicsCRM::XML::Fault.new(fault)
       }
 
@@ -23,7 +23,7 @@ describe DynamicsCRM::XML::Fault do
 
       subject {
         document = REXML::Document.new(fixture('sender_fault'))
-        fault = document.get_elements("//[local-name() = 'Fault']")
+        fault = document.get_elements("//*[local-name() = 'Fault']")
         DynamicsCRM::XML::Fault.new(fault)
       }
 


### PR DESCRIPTION
When updating to Ruby 2.6.0 I stumbled across the following error:

```bash
error: Unexpected node test: <:predicate>: <[[:eq, [:function, "local-name", []], [:literal, "Fault"]]]>
```

I believe the issue stems from changes to the underlying REXML gem, making the previous xpath query invalid.